### PR TITLE
Fix free variable issue

### DIFF
--- a/org-readme.el
+++ b/org-readme.el
@@ -935,7 +935,7 @@ If N is provided return all matches of the Nth subexpression of REGEX."
   (let ((lst (org-readme-get-matches
 	      "(\\(?:cl-\\)?def\\(?:un\\|macro\\)[*]?[ \t\n]+\\([^ \t\n]+\\)" 1))
 	(readme (org-readme-find-readme))
-	tmp ret1 ret2 ret)
+	tmp ret1 ret2 ret3 ret)
     (cl-flet ((fd (x)
 		  (with-temp-buffer
 		    (insert x)


### PR DESCRIPTION
Declare 'ret3' as local variable.

This fixes following byte-compile warnings.

```
In org-readme-insert-functions:
org-readme.el:972:24:Warning: assignment to free variable `ret3'
org-readme.el:978:84:Warning: reference to free variable `ret3
```
